### PR TITLE
Explicitly set ubuntu github runners to 20.04

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   unittest:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR addresses #42. Gcc-7 seems to no longer be available on 22. This explicitly sets `ubuntu-20.04` for PR unitests.