### PR TITLE
Enable peptide score for all peptides regardless of the modification state

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -34,7 +34,6 @@ jobs:
         architecture: x64
     - name: Install in place
       run: |
-        $env:PYASCORE_COMPILE_ARGS = '/std:c++latest'
         python -m pip install --upgrade pip
         pip install -e .
     - name: Run python unittest

--- a/pyascore/ptm_scoring/cpp/Ascore.cpp
+++ b/pyascore/ptm_scoring/cpp/Ascore.cpp
@@ -38,9 +38,6 @@ namespace ptmscoring {
     bool Ascore::isUnambiguous () {
 
         if (modified_peptide_ptr->getNumberOfMods() >= modified_peptide_ptr->getNumberModifiable()){
-            peptide_scores_.push_back( {} );
-            peptide_scores_.front().signature.resize(modified_peptide_ptr->getNumberOfMods(), 1);
-            peptide_scores_.front().weighted_score = std::numeric_limits<float>::infinity();
             for (size_t ind = 0; ind < modified_peptide_ptr->getNumberOfMods(); ind++){
                 ascore_containers_.push_back({
                     ind, {}, {}, {std::numeric_limits<float>::infinity()}
@@ -185,7 +182,7 @@ namespace ptmscoring {
 
             ion_trials[0] += ions[0].size();
             for (float mz : ions[0]){
-                if (modified_peptide_ptr->hasMatch(mz) and
+                if (modified_peptide_ptr->hasMatch(mz) &&
                     std::get<1>(modified_peptide_ptr->getMatch(mz)) <= max_score_depth){
                     ion_counts[0]++;
                 }
@@ -193,7 +190,7 @@ namespace ptmscoring {
 
             ion_trials[1] += ions[1].size();
             for (float mz : ions[1]){
-                if (modified_peptide_ptr->hasMatch(mz) and
+                if (modified_peptide_ptr->hasMatch(mz) &&
                     std::get<1>(modified_peptide_ptr->getMatch(mz)) <= max_score_depth){
                     ion_counts[1]++;
                 }
@@ -230,11 +227,11 @@ namespace ptmscoring {
             std::vector<size_t>::iterator best_it = best_score.signature.begin();
             std::vector<size_t>::iterator comp_it = competing_score.signature.begin();
             for (; best_it < best_score.signature.end(); best_it++, comp_it++) {
-                if (*best_it and *comp_it) {
+                if (*best_it && *comp_it) {
                     same_count++;
-                } else if (*best_it and not *comp_it) {
+                } else if (*best_it && (!*comp_it)) {
                     ascore_ind = same_count;
-                } else if (not *best_it and *comp_it) {
+                } else if ((! *best_it) && *comp_it) {
                     comp_sig_ind = comp_it - competing_score.signature.begin();
                 }
             }
@@ -264,9 +261,10 @@ namespace ptmscoring {
         resetInternalState();
 
         // Score pipeline
-        if ( not isUnambiguous() ){
-            accumulateCounts();
-            calculateFullScores();
+	accumulateCounts();
+        calculateFullScores();
+	    
+        if ( !isUnambiguous() ){
             sortScores();
             calculateAscores();
         }

--- a/pyascore/ptm_scoring/cpp/ModifiedPeptide.cpp
+++ b/pyascore/ptm_scoring/cpp/ModifiedPeptide.cpp
@@ -132,10 +132,10 @@ namespace ptmscoring {
         for(; it < fragments.end(); it++) {
             ppm_low = *it - mz_error;
             ppm_high = *it + mz_error;
-            if (mz > ppm_low and mz < ppm_high) {
-                if (!fragment_scores.count(*it) or std::get<1>(fragment_scores.at(*it)) > rank) {
-                    fragment_scores[*it] = {mz, rank}; // The theoretical mz needs to be the key
-                }
+            if ((mz > ppm_low) && (mz < ppm_high)) {
+		    if ((!fragment_scores.count(*it)) || (std::get<1>(fragment_scores.at(*it)) > rank)) {
+			    fragment_scores[*it] = {mz, rank}; // The theoretical mz needs to be the key
+		    }
             } else if (mz < ppm_low) {break;}
         }
 
@@ -183,7 +183,7 @@ namespace ptmscoring {
 
     size_t ModifiedPeptide::getPosOfNthModifiable (size_t n) const {
         for (size_t ind = 0; ind < residues.size(); ind++) {
-            if (residues.at(ind).size() > 1 and n == 0) {
+            if ((residues.at(ind).size() > 1) && (n == 0)) {
                 return ind;
             } else if (residues.at(ind).size() > 1) {
                 n--;
@@ -436,7 +436,7 @@ namespace ptmscoring {
         n_mods_outstanding = 1;
         size_t final_index = modified_peptide->residues.size();
         for (std::vector<size_t>::iterator it = --modifiable.end();
-             it >= modifiable.begin() and n_mods_outstanding; 
+             it >= modifiable.begin() && n_mods_outstanding; 
              it--) {
             if ( signature.at(*it) > 0 ) {
                 final_index = *it;
@@ -499,7 +499,7 @@ namespace ptmscoring {
 
     void ModifiedPeptide::FragmentGraph::incrFragment () {
         // Don't increment if fragment end or signature end
-        if (isSignatureEnd() or isFragmentEnd()) {throw 40;}
+        if (isSignatureEnd() || isFragmentEnd()) {throw 40;}
 
         // Only increment residue if more losses are not available
         if ( neutral_loss_iter.hasNext() ) {

--- a/pyascore/ptm_scoring/cpp/Util.cpp
+++ b/pyascore/ptm_scoring/cpp/Util.cpp
@@ -65,7 +65,7 @@ namespace ptmscoring {
         } else if (successes == 0) { return 0.; }
 
         size_t starting_k = successes;
-        while(cache.count(bit_concat(starting_k, trials)) == 0 and starting_k < trials + 1) {
+        while((cache.count(bit_concat(starting_k, trials)) == 0) && (starting_k < trials + 1)) {
             starting_k++;
         }
 


### PR DESCRIPTION
This PR is the squashed version of https://github.com/Villen-Lab/pyAscore/pull/41. It closes #40 and removes the latest C++ requirement from windows builds.