### PR TITLE
removed queue_size parameter from PercolatorTXT() call in id_parsers.py

### DIFF
--- a/pyascore/parsing/id_parsers.py
+++ b/pyascore/parsing/id_parsers.py
@@ -707,10 +707,10 @@ class IdentificationParser:
             self._reader = PepXML(id_file_name, queue_size=32767)
             self._extractor = PepXMLExtractor(score_string)
         elif id_file_format == "percolatorTXT":
-            self._reader = PercolatorTXT(id_file_name, queue_size=32767)
+            self._reader = PercolatorTXT(id_file_name)
             self._extractor = PercolatorTXTExtractor(score_string, static_mods)
         elif id_file_format == "mokapotTXT":
-            self._reader = MokapotTXT(id_file_name, queue_size=32767)
+            self._reader = MokapotTXT(id_file_name)
             self._extractor = MokapotTXTExtractor(score_string, static_mods)
         else:
             raise ValueError("{} not supported at this time."


### PR DESCRIPTION
Hi,
I was having issues with reading files in percolatorTXT format.
I think this change should be enough, but I haven't tested it.